### PR TITLE
removed numpy dependancy from package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -21,8 +21,6 @@ dependencies:
   - more-itertools=8.2.0=py_0
   - mypy_extensions=0.4.3=py38_0
   - ncurses=6.2=h0a44026_0
-  - numpy=1.18.1=py38h7241aed_0
-  - numpy-base=1.18.1=py38h6575580_1
   - openssl=1.1.1g=h1de35cc_0
   - packaging=20.3=py_0
   - pathspec=0.7.0=py_0

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,6 @@ mistune==0.8.4
 mkdir==2019.4.13
 more-itertools==8.2.0
 mypy-extensions==0.4.3
-numpy==1.18.1
 orderdict==2019.9.25
 packaging==20.3
 pathspec==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,6 @@ setup(
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.5",
-    install_requires=["numpy"],
+    install_requires=["rtree"],
     test_requires=["pytest", "pytest-cov"],
 )

--- a/turf/area/_area.py
+++ b/turf/area/_area.py
@@ -1,5 +1,5 @@
-import numpy as np
 from functools import reduce
+from math import sin
 
 from turf.invariant import get_geometry_from_features, get_coords_from_geometry
 from turf.helpers import (
@@ -109,7 +109,7 @@ def ring_area(coords):
             p2 = coords[middle_index]
             p3 = coords[upper_index]
 
-            total += (rad(p3[0]) - rad(p1[0])) * np.sin(rad(p2[1]))
+            total += (rad(p3[0]) - rad(p1[0])) * sin(rad(p2[1]))
 
         total = total * earth_radius ** 2 / 2
 

--- a/turf/bbox/_bbox.py
+++ b/turf/bbox/_bbox.py
@@ -1,7 +1,5 @@
 from functools import reduce
 
-import numpy as np
-
 from turf.invariant import get_coords_from_features
 from turf.utils.helpers import get_input_dimensions
 
@@ -14,7 +12,7 @@ def bbox(features):
     :return: bounding box extent in [minX, minY, maxX, maxY] order
     """
 
-    bounding_box = [np.inf, np.inf, -np.inf, -np.inf]
+    bounding_box = [float("inf"), float("inf"), float("-inf"), float("-inf")]
 
     coords = get_coords_from_features(features)
 

--- a/turf/bearing/_bearing.py
+++ b/turf/bearing/_bearing.py
@@ -1,4 +1,4 @@
-import numpy as np
+from math import sin, cos, atan2
 
 from turf.invariant import get_coords_from_features
 from turf.helpers import degrees_to_radians, radians_to_degrees
@@ -30,11 +30,11 @@ def bearing(start, end, options=None):
     lat1 = degrees_to_radians(start[1])
     lat2 = degrees_to_radians(end[1])
 
-    a = np.sin(lon2 - lon1) * np.cos(lat2)
+    a = sin(lon2 - lon1) * cos(lat2)
 
-    b = np.cos(lat1) * np.sin(lat2) - np.sin(lat1) * np.cos(lat2) * np.cos(lon2 - lon1)
+    b = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(lon2 - lon1)
 
-    return radians_to_degrees(np.arctan2(a, b))
+    return radians_to_degrees(atan2(a, b))
 
 
 def calculate_final_bearing(start, end):

--- a/turf/boolean_point_on_line/_boolean_point_on_line.py
+++ b/turf/boolean_point_on_line/_boolean_point_on_line.py
@@ -2,12 +2,10 @@ from typing import Dict, List, Sequence, TypeVar, Union
 from decimal import Decimal, getcontext
 from math import sqrt
 
-import numpy as np
-
 from turf.helpers import Feature, LineString, Point
-
 from turf.helpers import feature_collection, line_string, multi_line_string
 from turf.invariant import get_coords_from_features
+
 
 ctx = getcontext()
 ctx.prec = 28

--- a/turf/destination/_destination.py
+++ b/turf/destination/_destination.py
@@ -1,4 +1,4 @@
-import numpy as np
+from math import asin, atan2, cos, sin
 
 from turf.helpers import (
     degrees_to_radians,
@@ -40,14 +40,14 @@ def destination(origin, distance, bearing, options=None):
 
     radians = length_to_radians(distance, **kwargs)
 
-    latitude2 = np.arcsin(
-        np.sin(latitude1) * np.cos(radians)
-        + np.cos(latitude1) * np.sin(radians) * np.cos(bearing_rads)
+    latitude2 = asin(
+        sin(latitude1) * cos(radians)
+        + cos(latitude1) * sin(radians) * cos(bearing_rads)
     )
 
-    longitude2 = longitude1 + np.arctan2(
-        np.sin(bearing_rads) * np.sin(radians) * np.cos(latitude1),
-        np.cos(radians) - np.sin(latitude1) * np.sin(latitude2),
+    longitude2 = longitude1 + atan2(
+        sin(bearing_rads) * sin(radians) * cos(latitude1),
+        cos(radians) - sin(latitude1) * sin(latitude2),
     )
 
     lng = truncate(radians_to_degrees(longitude2), 6)

--- a/turf/distance/_distance.py
+++ b/turf/distance/_distance.py
@@ -1,4 +1,5 @@
-import numpy as np
+from math import atan2, cos, sin, sqrt
+
 from turf.helpers import degrees_to_radians, radians_to_length
 from turf.invariant import get_coords_from_features
 
@@ -47,9 +48,7 @@ def calculate_radians_distance(dif_lon, dif_lat, lat1, lat2):
 
     :return: distance_radians
     """
-    d = np.sin(dif_lat / 2) ** 2 + np.sin(dif_lon / 2) ** 2 * np.cos(lat1) * np.cos(
-        lat2
-    )
-    d = 2 * np.arctan2(np.sqrt(d), np.sqrt(1 - d))
+    d = sin(dif_lat / 2) ** 2 + sin(dif_lon / 2) ** 2 * cos(lat1) * cos(lat2)
+    d = 2 * atan2(sqrt(d), sqrt(1 - d))
 
     return d

--- a/turf/helpers/_conversions.py
+++ b/turf/helpers/_conversions.py
@@ -1,4 +1,5 @@
-import numpy as np
+from math import pi
+from typing import List
 
 from turf.helpers._units import factors, area_factors
 from turf.utils.exceptions import InvalidInput
@@ -8,6 +9,21 @@ from turf.utils.error_codes import error_code_messages
 def c_like_modulo(number, base):
 
     return number - int(number / base) * base
+
+
+def dot(vector_1: List, vector_2: List) -> float:
+    """
+    Dot product of two lists
+
+    :param vector_1: list of values
+    :param vector_2: list of values
+
+    :return: dot product
+    """
+    if len(vector_1) != len(vector_2):
+        raise InvalidInput(error_code_messages["InvalidLength"])
+
+    return sum(x * y for x, y in zip(vector_1, vector_2))
 
 
 def degrees_to_radians(degrees):
@@ -20,7 +36,7 @@ def degrees_to_radians(degrees):
         raise InvalidInput(error_code_messages["InvalidDegrees"])
 
     radians = c_like_modulo(degrees, 360)
-    return radians * np.pi / 180
+    return radians * pi / 180
 
 
 def radians_to_degrees(radians):
@@ -32,8 +48,8 @@ def radians_to_degrees(radians):
     if not isinstance(radians, (float, int)):
         raise InvalidInput(error_code_messages["InvalidRadians"])
 
-    degrees = c_like_modulo(radians, 2 * np.pi)
-    return degrees * 180 / np.pi
+    degrees = c_like_modulo(radians, 2 * pi)
+    return degrees * 180 / pi
 
 
 def length_to_radians(distance, units="kilometers"):

--- a/turf/helpers/tests/test_conversions.py
+++ b/turf/helpers/tests/test_conversions.py
@@ -1,5 +1,5 @@
 import pytest
-import numpy as np
+from math import pi
 
 from turf.helpers._units import earth_radius
 from turf.helpers import (
@@ -55,9 +55,9 @@ def test_length_to_degrees(value, units, result):
 @pytest.mark.parametrize(
     "value,result",
     [
-        pytest.param(np.pi / 3, 60, id="radiance conversion PI/3"),
-        pytest.param(3.5 * np.pi, 270, id="radiance conversion 3.5 PI"),
-        pytest.param(-1 * np.pi, -180, id="radiance conversion -PI"),
+        pytest.param(pi / 3, 60, id="radiance conversion PI/3"),
+        pytest.param(3.5 * pi, 270, id="radiance conversion 3.5 PI"),
+        pytest.param(-1 * pi, -180, id="radiance conversion -PI"),
     ],
 )
 def test_radians_to_degrees(value, result):
@@ -68,9 +68,9 @@ def test_radians_to_degrees(value, result):
 @pytest.mark.parametrize(
     "value,result",
     [
-        pytest.param(60, np.pi / 3, id="degrees conversion 60"),
-        pytest.param(270, 1.5 * np.pi, id="degrees conversion 270"),
-        pytest.param(-180, -np.pi, id="degrees conversion -180"),
+        pytest.param(60, pi / 3, id="degrees conversion 60"),
+        pytest.param(270, 1.5 * pi, id="degrees conversion 270"),
+        pytest.param(-180, -pi, id="degrees conversion -180"),
     ],
 )
 def test_degrees_to_radians(value, result):

--- a/turf/point_on_feature/_point_on_feature.py
+++ b/turf/point_on_feature/_point_on_feature.py
@@ -1,7 +1,5 @@
 from typing import List, TypeVar, Union
 
-import numpy as np
-
 from turf.boolean_point_in_polygon import boolean_point_in_polygon
 from turf.center import center
 from turf.explode import explode

--- a/turf/point_to_line_distance/_point_to_line_distance.py
+++ b/turf/point_to_line_distance/_point_to_line_distance.py
@@ -1,10 +1,8 @@
 from typing import Dict, List, Sequence, Union
 
-import numpy as np
-
 from turf.distance import distance
 from turf.rhumb_distance import rhumb_distance
-from turf.helpers import convert_length, Feature
+from turf.helpers import convert_length, dot, Feature
 from turf.invariant import get_coords_from_features
 
 
@@ -65,8 +63,8 @@ def get_distance_to_segment(
 
     w = [point[0] - segment_start[0], point[1] - segment_start[1]]
 
-    c1 = np.dot(w, v)
-    c2 = np.dot(v, v)
+    c1 = dot(w, v)
+    c2 = dot(v, v)
 
     b2 = c1 / c2
     point_2 = [segment_start[0] + (b2 * v[0]), segment_start[1] + (b2 * v[1])]

--- a/turf/rhumb_bearing/_rhumb_bearing.py
+++ b/turf/rhumb_bearing/_rhumb_bearing.py
@@ -1,7 +1,5 @@
-from math import fmod
+from math import atan2, fmod, log, pi, tan
 from typing import Dict, Sequence, Union
-
-import numpy as np
 
 from turf.helpers import degrees_to_radians, radians_to_degrees
 from turf.helpers import Feature
@@ -52,13 +50,13 @@ def calculate_rhumb_bearing(origin: Sequence, destination: Sequence) -> float:
     delta_lambda = degrees_to_radians(destination[0] - origin[0])
 
     # if delta_lambda over 180° take shorter rhumb line across the anti-meridian:
-    if abs(delta_lambda) > np.pi:
+    if abs(delta_lambda) > pi:
         if delta_lambda > 0:
-            delta_lambda = -(2 * np.pi - delta_lambda)
+            delta_lambda = -(2 * pi - delta_lambda)
         if delta_lambda < 0:
-            delta_lambda = 2 * np.pi + delta_lambda
+            delta_lambda = 2 * pi + delta_lambda
 
-    delta_psi = np.log(np.tan(phi_2 / 2 + np.pi / 4) / np.tan(phi_1 / 2 + np.pi / 4))
-    theta = np.arctan2(delta_lambda, delta_psi)
+    delta_psi = log(tan(phi_2 / 2 + pi / 4) / tan(phi_1 / 2 + pi / 4))
+    theta = atan2(delta_lambda, delta_psi)
 
     return fmod(radians_to_degrees(theta) + 360, 360)

--- a/turf/rhumb_destination/_rhumb_destination.py
+++ b/turf/rhumb_destination/_rhumb_destination.py
@@ -1,7 +1,5 @@
-from math import fmod
+from math import cos, fmod, log, pi, sin, tan
 from typing import Dict, List, Sequence, Union
-
-import numpy as np
 
 from turf.helpers import convert_length, degrees_to_radians
 from turf.helpers import earth_radius
@@ -82,35 +80,35 @@ def calculate_rhumb_destination(
     # angular distance in radians
     delta = distance_in_meters / radius
     # to radians, but without normalize to pi
-    lambda_1 = origin[0] * np.pi / 180
+    lambda_1 = origin[0] * pi / 180
 
     phi_1 = degrees_to_radians(origin[1])
     theta = degrees_to_radians(bearing)
 
-    delta_phi = delta * np.cos(theta)
+    delta_phi = delta * cos(theta)
     phi_2 = phi_1 + delta_phi
 
     # check for some points going past the pole, normalise latitude if so
-    if abs(phi_2) > (np.pi / 2) and (phi_2 > 0):
-        phi_2 = np.pi - phi_2
-    if abs(phi_2) > (np.pi / 2) and (phi_2 < 0):
-        phi_2 = np.pi - phi_2
+    if abs(phi_2) > (pi / 2) and (phi_2 > 0):
+        phi_2 = pi - phi_2
+    if abs(phi_2) > (pi / 2) and (phi_2 < 0):
+        phi_2 = pi - phi_2
 
-    delta_psi = np.log(np.tan(phi_2 / 2 + np.pi / 4) / np.tan(phi_1 / 2 + np.pi / 4))
+    delta_psi = log(tan(phi_2 / 2 + pi / 4) / tan(phi_1 / 2 + pi / 4))
 
     # E-W course becomes ill-conditioned with 0/0
     if abs(delta_psi) > 10e-12:
         q_1 = delta_phi / delta_psi
     else:
-        q_1 = np.cos(phi_1)
+        q_1 = cos(phi_1)
 
-    delta_lambda = delta * np.sin(theta) / q_1
+    delta_lambda = delta * sin(theta) / q_1
     lambda_2 = lambda_1 + delta_lambda
 
     # normalise to −180..+180°
     destination = [
-        fmod(((lambda_2 * 180 / np.pi) + 540), 360) - 180,
-        (phi_2 * 180 / np.pi),
+        fmod(((lambda_2 * 180 / pi) + 540), 360) - 180,
+        (phi_2 * 180 / pi),
     ]
 
     return destination

--- a/turf/rhumb_distance/_rhumb_distance.py
+++ b/turf/rhumb_distance/_rhumb_distance.py
@@ -1,6 +1,5 @@
 from typing import Dict, List
-
-import numpy as np
+from math import cos, log, pi, sqrt, tan
 
 from turf.helpers import convert_length, degrees_to_radians
 from turf.helpers import earth_radius
@@ -67,21 +66,21 @@ def calculate_rhumb_distance(
     delta_lambda = degrees_to_radians(abs(destination[0] - origin[0]))
 
     # if dLon over 180° take shorter rhumb line across the anti-meridian:
-    if delta_lambda > np.pi:
-        delta_lambda -= 2 * np.pi
+    if delta_lambda > pi:
+        delta_lambda -= 2 * pi
 
     # on Mercator projection, longitude distances shrink by latitude; q is the 'stretch factor'
     # q becomes ill-conditioned along E-W line (0/0); use empirical tolerance to avoid it
 
-    delta_psi = np.log(np.tan(phi_2 / 2 + np.pi / 4) / np.tan(phi_1 / 2 + np.pi / 4))
+    delta_psi = log(tan(phi_2 / 2 + pi / 4) / tan(phi_1 / 2 + pi / 4))
 
     if abs(delta_psi) > 10e-12:
         q_1 = delta_phi / delta_psi
     else:
-        q_1 = np.cos(phi_1)
+        q_1 = cos(phi_1)
 
     # distance is pythagoras on 'stretched' Mercator projection
-    delta = np.sqrt(delta_phi * delta_phi + q_1 * q_1 * delta_lambda * delta_lambda)
+    delta = sqrt(delta_phi * delta_phi + q_1 * q_1 * delta_lambda * delta_lambda)
     # angular distance in radians
     distance = delta * radius
 


### PR DESCRIPTION
Based on this [issue #48](https://github.com/pyturf/pyturf/issues/48), the numpy library has been removed.

make sure that:

- [x] You have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ x You Include a link to the issue this pull request is associated to.
- [x] The linter has been run at the root level of the project: `black .`
- [x] All tests are passing: `python -m pytest --verbose --cov=./` 
- [x] Your branch is up to date with master: `git rebase upstream/master`

For new modules, also make sure that:

- [ ] The new module function is exported in `turf/<your-module>/__init__.py` and `turf/__init__.py`.
- [ ] The new module has been added under the `Available Modules` section on the [README](../README.md).
