### PR TITLE
remove double quotations for proper pypi metadata versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,15 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 try:
-    __version__ = os.environ["GITHUB_REF"].split("/")[-1]
+    __version__ = os.environ["GITHUB_REF"].split("/")[-1].strip('"')
     print(f"Version: {__version__}")
 except KeyError:
     try:
         from turf.version import __version__
     except ModuleNotFoundError:
-        __version__ = str(open("turf/version.py").read().split(" ")[-1].splitlines()[0])
+        __version__ = str(
+            open("turf/version.py").read().split(" ")[-1].splitlines()[0]
+        ).strip('"')
 
 setup(
     name="pyturf",


### PR DESCRIPTION
This fix solves the issue of [appearing dashes in the metadata](https://github.com/pyturf/pyturf/issues/61).



Please make sure that:

- [x] You have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] You Include a link to the issue this pull request is associated to.
- [x] The linter has been run at the root level of the project: `black .`
- [x] All tests are passing: `python -m pytest --verbose --cov=./` 
- [x] Your branch is up to date with master: `git rebase upstream/master`

For new modules, also make sure that:

- [ ] The new module function is exported in `turf/<your-module>/__init__.py` and `turf/__init__.py`.
- [ ] The new module has been added under the `Available Modules` section on the [README](../README.md).
